### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-math9 (8.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 20:54:48 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/copyright

--- a/jammy/debian/docs
+++ b/jammy/debian/docs
@@ -1,1 +1,0 @@
-../../ubuntu/debian/docs

--- a/jammy/debian/libgz-math9-dev.install
+++ b/jammy/debian/libgz-math9-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-math-dev.install

--- a/jammy/debian/libgz-math9-eigen3-dev.install
+++ b/jammy/debian/libgz-math9-eigen3-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-math-eigen3-dev.install

--- a/jammy/debian/libgz-math9.install
+++ b/jammy/debian/libgz-math9.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-math.install

--- a/jammy/debian/python3-gz-math9.install
+++ b/jammy/debian/python3-gz-math9.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/python3-gz-math.install

--- a/jammy/debian/ruby-gz-math9.install
+++ b/jammy/debian/ruby-gz-math9.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/ruby-gz-math.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source

--- a/jammy/debian/tests
+++ b/jammy/debian/tests
@@ -1,1 +1,0 @@
-../../ubuntu/debian/tests/

--- a/jammy/debian/watch
+++ b/jammy/debian/watch
@@ -1,1 +1,0 @@
-../../ubuntu/debian/watch


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.