### PR TITLE
Add gz-jetty-math alias packages

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -124,3 +124,35 @@ Description: Gazebo Math Library - Debugging symbols
  functionality to bootstrap robot applications. The included libraries
  encapsulate all the essentials, such as common math data types, console
  logging, 3D mesh management, and asynchronous message passing.
+
+Package: gz-jetty-math
+Depends: libgz-math9-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: gz-jetty-math-eigen3
+Depends: libgz-math9-eigen3-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: gz-jetty-math-python
+Depends: python3-gz-math9 (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: gz-jetty-math-ruby
+Depends: ruby-gz-math9 (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.


### PR DESCRIPTION
Adds gz-jetty-math, gz-jetty-math-eigen3,
gz-jetty-math-python, and gz-jetty-math-ruby packages that depend on libgz-math9-dev, libgz-math9-eigen3-dev, python3-gz-math9, and ruby-gz-math9 respectively to allow installing Jetty packages without knowing the version number.

Part of https://github.com/gazebo-tooling/release-tools/issues/1326.